### PR TITLE
Adding support for enforced ordering

### DIFF
--- a/packages/dss-bridge/src/DomainHost.sol
+++ b/packages/dss-bridge/src/DomainHost.sol
@@ -67,7 +67,6 @@ abstract contract DomainHost {
     RouterLike  public immutable router;
 
     address public vow;
-    uint256 public liftId;      // To track the ordering on lift
     uint256 public line;        // Remote domain global debt ceiling [RAD]
     uint256 public grain;       // Keep track of the pre-minted DAI in the escrow [WAD]
     uint256 public cure;        // The amount of unused debt [RAD]
@@ -174,7 +173,7 @@ abstract contract DomainHost {
 
         line = rad;
 
-        _lift(++liftId, rad, minted);
+        _lift(rad, minted);
 
         emit Lift(wad);
     }
@@ -297,7 +296,7 @@ abstract contract DomainHost {
 
     // Bridge-specific functions
     function _isGuest(address usr) internal virtual view returns (bool);
-    function _lift(uint256 id, uint256 line, uint256 minted) internal virtual;
+    function _lift(uint256 line, uint256 minted) internal virtual;
     function _rectify(uint256 wad) internal virtual;
     function _cage() internal virtual;
     function _mintClaim(address usr, uint256 claim) internal virtual;

--- a/packages/dss-bridge/src/DomainHost.sol
+++ b/packages/dss-bridge/src/DomainHost.sol
@@ -172,7 +172,15 @@ abstract contract DomainHost {
         if (success) {
             nextId = _nextId;
         } else {
-            revert(string(response));
+            string memory message;
+            assembly {
+                let size := mload(add(response, 0x44))
+                message := mload(0x40)
+                mstore(message, size)
+                mstore(0x40, add(message, and(add(add(size, 0x20), 0x1f), not(0x1f))))
+                returndatacopy(add(message, 0x20), 0x44, size)
+            }
+            revert(string(message));
         }
     }
 

--- a/packages/dss-bridge/src/tests/DomainGuest.t.sol
+++ b/packages/dss-bridge/src/tests/DomainGuest.t.sol
@@ -242,6 +242,14 @@ contract DomainGuestTest is DSSTest {
         guest.next();
     }
 
+    function testNextMessageUnavailableOutOfOrder() public {
+        bytes memory data = abi.encodeWithSelector(DomainGuest.lift.selector, 100 * RAD, 100 ether);
+        guest.enqueue(2, data);
+
+        vm.expectRevert("DomainGuest/message-unavailable");
+        guest.next();
+    }
+
     function testNextMessageRevert() public {
         // Encode a function call that will revert
         bytes memory data = abi.encodeWithSelector(DomainGuest.release.selector);

--- a/packages/dss-bridge/src/tests/DomainHost.t.sol
+++ b/packages/dss-bridge/src/tests/DomainHost.t.sol
@@ -32,7 +32,6 @@ import "../TeleportGUID.sol";
 contract EmptyDomainHost is DomainHost {
 
     bool forceIsGuest = true;
-    uint256 public liftIdEmpty;
     uint256 public liftLine;
     uint256 public liftMinted;
     uint256 public rectify;
@@ -50,8 +49,7 @@ contract EmptyDomainHost is DomainHost {
     function _isGuest(address) internal override view returns (bool) {
         return forceIsGuest;
     }
-    function _lift(uint256 _id, uint256 _line, uint256 _minted) internal override {
-        liftIdEmpty = _id;
+    function _lift(uint256 _line, uint256 _minted) internal override {
         liftLine = _line;
         liftMinted = _minted;
     }
@@ -197,8 +195,6 @@ contract DomainHostTest is DSSTest {
         assertEq(dai.balanceOf(address(escrow)), 100 ether);
         assertEq(host.line(), 100 * RAD);
         assertEq(host.grain(), 100 ether);
-        assertEq(host.liftId(), 1);
-        assertEq(host.liftIdEmpty(), 1);
         assertEq(host.liftLine(), 100 * RAD);
         assertEq(host.liftMinted(), 100 ether);
 
@@ -211,8 +207,6 @@ contract DomainHostTest is DSSTest {
         assertEq(dai.balanceOf(address(escrow)), 200 ether);
         assertEq(host.line(), 200 * RAD);
         assertEq(host.grain(), 200 ether);
-        assertEq(host.liftId(), 2);
-        assertEq(host.liftIdEmpty(), 2);
         assertEq(host.liftLine(), 200 * RAD);
         assertEq(host.liftMinted(), 100 ether);
 
@@ -225,8 +219,6 @@ contract DomainHostTest is DSSTest {
         assertEq(dai.balanceOf(address(escrow)), 200 ether);
         assertEq(host.line(), 100 * RAD);
         assertEq(host.grain(), 200 ether);
-        assertEq(host.liftId(), 3);
-        assertEq(host.liftIdEmpty(), 3);
         assertEq(host.liftLine(), 100 * RAD);
         assertEq(host.liftMinted(), 0);
     }
@@ -241,8 +233,6 @@ contract DomainHostTest is DSSTest {
         assertEq(dai.balanceOf(address(escrow)), 100 ether);
         assertEq(host.line(), 100 * RAD);
         assertEq(host.grain(), 100 ether);
-        assertEq(host.liftId(), 1);
-        assertEq(host.liftIdEmpty(), 1);
         assertEq(host.liftLine(), 100 * RAD);
         assertEq(host.liftMinted(), 100 ether);
 
@@ -255,8 +245,6 @@ contract DomainHostTest is DSSTest {
         assertEq(dai.balanceOf(address(escrow)), 100 ether);
         assertEq(host.line(), 50 * RAD);
         assertEq(host.grain(), 100 ether);
-        assertEq(host.liftId(), 2);
-        assertEq(host.liftIdEmpty(), 2);
         assertEq(host.liftLine(), 50 * RAD);
         assertEq(host.liftMinted(), 0);
 
@@ -271,8 +259,6 @@ contract DomainHostTest is DSSTest {
         assertEq(dai.balanceOf(address(escrow)), 50 ether);
         assertEq(host.line(), 50 * RAD);
         assertEq(host.grain(), 50 ether);
-        assertEq(host.liftId(), 2);
-        assertEq(host.liftIdEmpty(), 2);
         assertEq(host.liftLine(), 50 * RAD);
         assertEq(host.liftMinted(), 0);
     }

--- a/packages/dss-bridge/src/tests/Integration.t.sol
+++ b/packages/dss-bridge/src/tests/Integration.t.sol
@@ -55,14 +55,17 @@ contract SimpleDomainHost is DomainHost {
     function _isGuest(address usr) internal override view returns (bool) {
         return usr == address(guest);
     }
-    function _lift(uint256 _line, uint256 _minted) internal override {
-        guest.lift(_line, _minted);
+    function _lift(uint256 _id, uint256 _line, uint256 _minted) internal override {
+        guest.enqueue(_id, abi.encodeWithSelector(DomainGuest.lift.selector, _line, _minted));
+        guest.next();
     }
-    function _rectify(uint256 wad) internal virtual override {
-        guest.rectify(wad);
+    function _rectify(uint256 _id, uint256 wad) internal virtual override {
+        guest.enqueue(_id, abi.encodeWithSelector(DomainGuest.rectify.selector, wad));
+        guest.next();
     }
-    function _cage() internal virtual override {
-        guest.cage();
+    function _cage(uint256 _id) internal virtual override {
+        guest.enqueue(_id, abi.encodeWithSelector(DomainGuest.cage.selector));
+        guest.next();
     }
     function _mintClaim(address usr, uint256 claim) internal virtual override {
         guest.mintClaim(usr, claim);
@@ -84,17 +87,21 @@ contract SimpleDomainGuest is DomainGuest {
     function _isHost(address usr) internal override view returns (bool) {
         return usr == address(usr);
     }
-    function _release(uint256 burned) internal override {
-        host.release(burned);
+    function _release(uint256 _id, uint256 burned) internal override {
+        host.enqueue(_id, abi.encodeWithSelector(DomainHost.release.selector, burned));
+        host.next();
     }
-    function _surplus(uint256 wad) internal virtual override {
-        host.surplus(wad);
+    function _surplus(uint256 _id, uint256 wad) internal virtual override {
+        host.enqueue(_id, abi.encodeWithSelector(DomainHost.surplus.selector, wad));
+        host.next();
     }
-    function _deficit(uint256 wad) internal virtual override {
-        host.deficit(wad);
+    function _deficit(uint256 _id, uint256 wad) internal virtual override {
+        host.enqueue(_id, abi.encodeWithSelector(DomainHost.deficit.selector, wad));
+        host.next();
     }
-    function _tell(uint256 value) internal virtual override {
-       host.tell(value);
+    function _tell(uint256 _id, uint256 value) internal virtual override {
+        host.enqueue(_id, abi.encodeWithSelector(DomainHost.tell.selector, value));
+        host.next();
     }
     function _initiateTeleport(TeleportGUID memory teleport) internal virtual override {
         host.teleportSlowPath(teleport);

--- a/packages/dss-bridge/src/tests/Integration.t.sol
+++ b/packages/dss-bridge/src/tests/Integration.t.sol
@@ -85,7 +85,7 @@ contract SimpleDomainGuest is DomainGuest {
     }
 
     function _isHost(address usr) internal override view returns (bool) {
-        return usr == address(usr);
+        return usr == address(host);
     }
     function _release(uint256 _id, uint256 burned) internal override {
         host.enqueue(_id, abi.encodeWithSelector(DomainHost.release.selector, burned));

--- a/packages/dss-bridge/src/tests/Integration.t.sol
+++ b/packages/dss-bridge/src/tests/Integration.t.sol
@@ -55,8 +55,8 @@ contract SimpleDomainHost is DomainHost {
     function _isGuest(address usr) internal override view returns (bool) {
         return usr == address(guest);
     }
-    function _lift(uint256 _id, uint256 _line, uint256 _minted) internal override {
-        guest.lift(_id, _line, _minted);
+    function _lift(uint256 _line, uint256 _minted) internal override {
+        guest.lift(_line, _minted);
     }
     function _rectify(uint256 wad) internal virtual override {
         guest.rectify(wad);


### PR DESCRIPTION
To simplify the mental model and reduce the chance of obscure ordering bugs we enforce serialized ordering of xchain messages at the application layer. This only applies to xdomain-dss messages.