### PR TITLE
Make tip sync delay longer

### DIFF
--- a/packages/teleport-monitoring/src/synchronizers/GenericSynchronizer.ts
+++ b/packages/teleport-monitoring/src/synchronizers/GenericSynchronizer.ts
@@ -11,7 +11,7 @@ export interface SyncOptions {
 }
 
 export const defaultSyncOptions: SyncOptions = {
-  tipSyncDelay: 5_000,
+  tipSyncDelay: 100_000,
   safeDistanceFromTip: 0,
 }
 


### PR DESCRIPTION
@cristidas 

At the moment the monitor service makes A LOT of RPC endpoint requests. This should slow it down without hopefully impacting the functionality.